### PR TITLE
Make minor fix

### DIFF
--- a/php/joinBill.php
+++ b/php/joinBill.php
@@ -33,7 +33,7 @@
    $results = mysqli_query($conn, $sql) or print_error("Can't run SQL query. Query = $sql");
 
 // If the bill exists, update user count, give user all the items to display on page
-   if($results) {
+   if(mysqli_num_rows($results) > 0) {
 
    // Update Count of Users
       $sql = "UPDATE Bills SET users = users + 1 WHERE bid=" . $_GET['bid'];


### PR DESCRIPTION
Hi! Only one line changed, joinBill normally has two checks, 1 if the bill exists, and 2 if there's any items. The checks should be the same, checking the amount of rows returned from the sql statement, but I accidentally was checking if the statement went through correctly (which or DIE() already takes care of). This was to fix that